### PR TITLE
Update jquery.serialize-object.js

### DIFF
--- a/jquery.serialize-object.js
+++ b/jquery.serialize-object.js
@@ -5,11 +5,11 @@
     json = {};
     push_counters = {};
     patterns = {
-      validate: /^[a-zA-Z][a-zA-Z0-9_]*(?:\[(?:\d*|[a-zA-Z0-9_]+)\])*$/,
-      key: /[a-zA-Z0-9_]+|(?=\[\])/g,
+      validate: /^[a-zA-Z][a-zA-Z0-9_\-]*(?:\[(?:\d*|[a-zA-Z0-9_\-]+)\])*$/,
+      key: /[a-zA-Z0-9_\-]+|(?=\[\])/g,
       push: /^$/,
-      fixed: /^\d+$/,
-      named: /^[a-zA-Z0-9_]+$/
+      fixed: /^\-\d+$/,
+      named: /^[a-zA-Z0-9_\-]+$/
     };
     this.build = function(base, key, value) {
       base[key] = value;


### PR DESCRIPTION
Changed regexes to allow a dash or '-' inside the name of the input field. I use this to indicate which are not saved and which are, e.g. a positive number indicates that it's saved, a negative if it's not.
