### PR TITLE
Fix problem with unit tests and update jQuery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Paul Macek <paulmacek@gmail.com> (https://github.com/macek)"
   ],
   "dependencies": {
-    "jquery": "^1.11.1"
+    "jquery": "1.11.1 - 2.1.x"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "url": "https://github.com/macek/jquery-serialize-object/issues"
   },
   "devDependencies": {
-    "uglify-js": "^2.4.32"
+    "uglify-js": "^2.4.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "serialize form fields into an object or JSON",
   "main": "./jquery.serialize-object.js",
   "scripts": {
-    "test": "npm run-script build && open ./test/test.html",
+    "test": "npm run-script build && xdg-open ./test/test.html",
     "build": "npm run-script minify",
     "minify": "uglifyjs jquery.serialize-object.js -m -c --comments > dist/jquery.serialize-object.min.js"
   },


### PR DESCRIPTION
I had a jQuery version conflict in my application (which used jQuery 2.1) due to jquery-serialize-object having a hard dependency on jQuery 1.8.  After updating the bower file and running the tests they all still pass.  It seems that you're not using any particular jQuery features that have been changed, so I've just made the selector a lot less strict.

To run the tests, I had to make another change because I got an obscure error message "Couldn't get a file descriptor referring to the console", which was due to the fact that under GNU/Linux (at least Debian and Ubuntu), "open" refers to "openvt", which requires a virtual terminal (on the physical console, so an xterm is not accepted). The fix is to use xdg-open.  However, this may break the test runner on OS X, so perhaps some kind of dispatching script is a better solution. See
https://github.com/gfestari/explain_shell/commit/bbc2d2c9bd507127bfd8cb6b67ef6a0151a5749b for example.