### PR TITLE
allow something like $('.inp1, inp2').serializeObject()

### DIFF
--- a/jquery.serialize-object.js
+++ b/jquery.serialize-object.js
@@ -124,9 +124,6 @@
   FormSerializer.patterns = patterns;
 
   FormSerializer.serializeObject = function serializeObject() {
-    if (this.length > 1) {
-      return new Error("jquery-serialize-object can only serialize one form at a time");
-    }
     return new FormSerializer($, this).
       addPairs(this.serializeArray()).
       serialize();


### PR DESCRIPTION
Or is there an important reason for this restriction?
